### PR TITLE
V0.15.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "wandb" %}
-{% set version = "0.13.11" %}
+{% set version = "0.15.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/wandb-{{ version }}.tar.gz
-  sha256: f2b065d1c732e8e1828fabe720dc82f12e6109d0d2bbfbcccc17eaefae0fd7c9
+  sha256: 2c39e129fb8dc69c7ff813aa52c2ce7f98e3a0f25c12dd96b1de7528d9443a84
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,9 @@ requirements:
     - wheel
     - python 
     - setuptools <64
+    
   run:
-    - click >=7.0,!=8.0.0
+    - click >=7.1,!=8.0.0
     - docker-pycreds >=0.4.0
     - gitpython >=1.0.0,!=3.1.29
     - pathtools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pip
     - wheel
     - python 
-    - setuptools <64
+    - setuptools
     
   run:
     - click >=7.1,!=8.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
   entry_points:
     - wandb=wandb.cli.cli:cli
     - wb=wandb.cli.cli:cli
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vvv
 
 requirements:
   host:


### PR DESCRIPTION
[Upstream Repo](https://github.com/wandb/wandb)

- Updated `click` pinning
- Added --no-build-isolation flag
