### PR TITLE
update to 0.27.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,12 @@
 @echo on
 
-PUSHD gpu_stats
-cargo-bundle-licenses --format yaml --output ../THIRDPARTY.yml || goto :error
+REM Bundle Rust licenses for xpu (formerly gpu_stats) and parquet-rust-wrapper
+PUSHD xpu
+cargo-bundle-licenses --format yaml --output ../THIRDPARTY_XPU.yml || goto :error
+POPD
+
+PUSHD parquet-rust-wrapper
+cargo-bundle-licenses --format yaml --output ../THIRDPARTY_PARQUET.yml || goto :error
 POPD
 
 %PYTHON% -m pip install --no-deps --no-build-isolation -vv .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,17 +2,25 @@
 
 set -o xtrace -o nounset -o pipefail -o errexit
 
-# crates.io index downloads flake on CI workers ("curl failed: Transferred a
-# partial file"); raise cargo's built-in network retry count
-export CARGO_NET_RETRY=10
+# crates.io downloads flake on CI workers ("curl failed: Transferred a partial
+# file") and cargo doesn't retry that error itself; retry at the shell level
+retry() {
+    local attempt
+    for attempt in 1 2 3; do
+        "$@" && return 0
+        echo "attempt ${attempt} failed: $*" >&2
+        sleep 15
+    done
+    return 1
+}
 
 # Bundle Rust licenses for xpu (formerly gpu_stats) and parquet-rust-wrapper
 pushd xpu
-cargo-bundle-licenses --format yaml --output ../THIRDPARTY_XPU.yml
+retry cargo-bundle-licenses --format yaml --output ../THIRDPARTY_XPU.yml
 popd
 
 pushd parquet-rust-wrapper
-cargo-bundle-licenses --format yaml --output ../THIRDPARTY_PARQUET.yml
+retry cargo-bundle-licenses --format yaml --output ../THIRDPARTY_PARQUET.yml
 popd
 
 # Unset CARGO_BUILD_TARGET: conda's rust compiler activation sets it, but

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,10 @@
 
 set -o xtrace -o nounset -o pipefail -o errexit
 
+# crates.io index downloads flake on CI workers ("curl failed: Transferred a
+# partial file"); raise cargo's built-in network retry count
+export CARGO_NET_RETRY=10
+
 # Bundle Rust licenses for xpu (formerly gpu_stats) and parquet-rust-wrapper
 pushd xpu
 cargo-bundle-licenses --format yaml --output ../THIRDPARTY_XPU.yml
@@ -15,6 +19,14 @@ popd
 # xpu/hatch.py hardcodes "target/release/" and doesn't account for the
 # target-triple subdirectory that CARGO_BUILD_TARGET introduces.
 unset CARGO_BUILD_TARGET
+
+# Build wandb-core with CGO: the default non-CGO path (new in 0.27.x) runs
+# objcopy --remove-section .gnu.version* on the binary (auditwheel workaround
+# in core/hatch.py) which corrupts it on our workers — wandb-core then
+# segfaults (exit -11) at startup. CGO uses the external linker (no strip).
+if [[ ${target_platform} == linux-* ]]; then
+    export WANDB_ENABLE_CGO=true
+fi
 
 ${PYTHON} -m pip install --no-deps --no-build-isolation -vv .
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,9 +2,19 @@
 
 set -o xtrace -o nounset -o pipefail -o errexit
 
-pushd gpu_stats
-cargo-bundle-licenses --format yaml --output ../THIRDPARTY.yml
+# Bundle Rust licenses for xpu (formerly gpu_stats) and parquet-rust-wrapper
+pushd xpu
+cargo-bundle-licenses --format yaml --output ../THIRDPARTY_XPU.yml
 popd
+
+pushd parquet-rust-wrapper
+cargo-bundle-licenses --format yaml --output ../THIRDPARTY_PARQUET.yml
+popd
+
+# Unset CARGO_BUILD_TARGET: conda's rust compiler activation sets it, but
+# xpu/hatch.py hardcodes "target/release/" and doesn't account for the
+# target-triple subdirectory that CARGO_BUILD_TARGET introduces.
+unset CARGO_BUILD_TARGET
 
 ${PYTHON} -m pip install --no-deps --no-build-isolation -vv .
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "wandb" %}
-{% set version = "0.25.1" %}
+{% set version = "0.27.2" %}
 
 package:
   name: {{ name }}
@@ -7,21 +7,22 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: bf823077098c31abce58abe680acf6b043ea3f96006e80c995dcb26160074449
+  sha256: ac7c70b8985c824e62f5bd3294e7bc5a57747de5ef7a298e7e071de185bcf485
 
 build:
   number: 0
   entry_points:
     - wandb=wandb.cli.cli:cli
     - wb=wandb.cli.cli:cli
-  # No rdkit and libboost-python-devel for py314
-  skip: true  # [py<39 or py>313]
+  # Lower bound: upstream requires-python >=3.10
+  # Upper bound: no rdkit (test dependency) for py314 yet
+  skip: true  # [py<310 or py>313]
 
 requirements:
   build:
-    # Selector is not work
-    #- {{ compiler('go-cgo') }}
-    - go-cgo 1.25.8
+    # {{ compiler('go-cgo') }} resolves to CBC cgo_compiler_version 1.21,
+    # too old for core/go.mod which requires go 1.26.4
+    - go-cgo 1.26.4
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
@@ -35,16 +36,15 @@ requirements:
     - typing-extensions
   run:
     - python
-    - click >=8.0.1
+    - click >=8.2.0
     - gitpython >=1.0.0,!=3.1.29
     - requests >=2.0.0,<3
     - sentry-sdk >=2.0.0
-    - protobuf >4.21.0,<7,!=5.28.0,!=5.29.0
+    - protobuf >4.21.0,<8,!=5.28.0,!=5.29.0
     - pyyaml
     - platformdirs
     - typing-extensions >=4.8,<5
-    - pydantic <3
-    - eval-type-backport  # [py<310]
+    - pydantic >=2.6,<3
     - packaging
 
 # ignoring integration tests (those has a lot of dependencies we don't have like azure, kubernetes, google-cloud,
@@ -130,7 +130,8 @@ about:
   license: MIT
   license_family: MIT
   license_file:
-    - THIRDPARTY.yml
+    - THIRDPARTY_XPU.yml
+    - THIRDPARTY_PARQUET.yml
     - LICENSE
   summary: A CLI and library for interacting with the Weights and Biases API.
   description:  |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,6 +103,9 @@ test:
     - wandb --help
     - wb --help
     - export GIT_PYTHON_REFRESH=quiet  # [not win]
+    # tempdir-fallback tests write to $TMPDIR/wandb; a stale /tmp/wandb owned by
+    # another task's user on reused workers makes that a PermissionError
+    - export TMPDIR=$(mktemp -d)  # [not win]
     - pytest tests -v -k "not ({{ skip_tests }})" {{ ignore_tests }}
   requires:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,8 @@ requirements:
 # requires 'looptime' (not available on defaults)
 {% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_lib/test_ratelimit.py" %}
 {% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_lib/test_run_messages.py" %}
+# requires 'cwsandbox' (sandbox extra, not available on defaults)
+{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_sandbox" %}
 # requres 'pytest-memray'
 {% set skip_tests = "test_opener_works_across_filesystem_boundaries" %}
 {% set skip_tests = skip_tests + " or test_md5_file_hashes_on_mounted_filesystem" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,11 @@ requirements:
 {% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_launch" %}
 # requires 'moviepy'
 {% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_data_types.py" %}
+# requires 'kfp' (not available on defaults)
+{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_kfp.py" %}
+# requires 'looptime' (not available on defaults)
+{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_lib/test_ratelimit.py" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_lib/test_run_messages.py" %}
 # requres 'pytest-memray'
 {% set skip_tests = "test_opener_works_across_filesystem_boundaries" %}
 {% set skip_tests = skip_tests + " or test_md5_file_hashes_on_mounted_filesystem" %}


### PR DESCRIPTION
wandb 0.27.2

**Destination channel:** defaults

### Links
- [PKG-14918](https://anaconda.atlassian.net/browse/PKG-14918)
- [GitHub](https://github.com/wandb/wandb/tree/v0.27.2)
- [PyPI](https://pypi.org/project/wandb/0.27.2/)
- [conda-forge](https://github.com/conda-forge/wandb-feedstock)

### Explanation of changes:
- Updated wandb from 0.25.1 to 0.27.2
- **Removed `abs.yaml`** — its `upload_channels: sfe1ed40` routed releases away from pkgs/main; this is why the 0.25.1 release (PKG-13045) never reached the main channel
- Python floor raised to 3.10 per upstream `requires-python >=3.10` (skip is now `py<310 or py>313`; py314 still blocked by rdkit test dependency)
- Dependency bounds synced with upstream pyproject.toml at v0.27.2:
  - `click >=8.2.0` (was >=8.0.1)
  - `protobuf <8` (was <7)
  - `pydantic >=2.6,<3` (was <3)
  - dropped `eval-type-backport` (only needed for py<310)
- `go-cgo` pin bumped 1.25.8 → 1.26.4 per `core/go.mod` at v0.27.2 (CBC `cgo_compiler_version` 1.21 is too old, so the hardpin stays)
- Build scripts: upstream renamed the Rust `gpu_stats` component to `xpu` and added a new `parquet-rust-wrapper` Rust component — license bundling updated accordingly (`THIRDPARTY_XPU.yml` + `THIRDPARTY_PARQUET.yml` in `license_file`)
- build.sh: added `unset CARGO_BUILD_TARGET` — conda's rust activation sets it, but upstream `xpu/hatch.py` hardcodes `target/release/` (same workaround as conda-forge)
- **build.sh: `WANDB_ENABLE_CGO=true` on linux** — upstream's default non-CGO path (new in 0.27.x) objcopy-strips `.gnu.version*` ELF sections from `wandb-core` ([auditwheel workaround in core/hatch.py](https://github.com/wandb/wandb/blob/v0.27.2/core/hatch.py#L82-L120)), which corrupts the binary on our workers — it segfaulted at service start, failing 12 unit tests per linux task. The CGO build uses the external linker (no strip) and exercises the go-cgo toolchain the recipe ships
- New test ignores with reasons — three modules new in 0.27.2 unconditionally import packages not on defaults: `test_kfp.py` (kfp), `test_lib/test_ratelimit.py` + `test_lib/test_run_messages.py` (looptime), `test_sandbox/` (cwsandbox)
- Tests run with a private `TMPDIR` — wandb's tempdir-fallback tests write `/tmp/wandb/...`, which hits PermissionError when a stale `/tmp/wandb` owned by a previous task's user exists on reused workers
- build.sh: retry loop around `cargo-bundle-licenses` — crates.io downloads flake on CI ("curl failed: Transferred a partial file", 6 build tasks across 3 graphs) and cargo doesn't retry that error class itself

[PKG-14918]: https://anaconda.atlassian.net/browse/PKG-14918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
