### PR TITLE
wandb 0.27.2 py3.14 build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,13 @@ source:
   sha256: ac7c70b8985c824e62f5bd3294e7bc5a57747de5ef7a298e7e071de185bcf485
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - wandb=wandb.cli.cli:cli
     - wb=wandb.cli.cli:cli
-  # Lower bound: upstream requires-python >=3.10
-  # Upper bound: no rdkit (test dependency) for py314 yet
-  skip: true  # [py<310 or py>313]
+  # Lower bound: upstream requires-python >=3.10. rdkit (a test-only dep) has no
+  # py3.14 build, so on py3.14 rdkit is dropped and its one test file is ignored.
+  skip: true  # [py<310]
 
 requirements:
   build:
@@ -60,6 +60,8 @@ requirements:
 {% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_lib/test_run_messages.py" %}
 # requires 'cwsandbox' (sandbox extra, not available on defaults)
 {% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_sandbox" %}
+# module-level `from rdkit import Chem`; rdkit has no py3.14 build on defaults
+{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_media/test_media_logging.py" %}  # [py>313]
 # requres 'pytest-memray'
 {% set skip_tests = "test_opener_works_across_filesystem_boundaries" %}
 {% set skip_tests = skip_tests + " or test_md5_file_hashes_on_mounted_filesystem" %}
@@ -131,7 +133,7 @@ test:
     - responses
     - flask
     - bokeh
-    - rdkit
+    - rdkit  # [py<314]
     - git
     - cloudpickle
 


### PR DESCRIPTION
wandb 0.27.2 py3.14 build

**Destination channel:** defaults

### Links

- [PKG-16711](https://anaconda.atlassian.net/browse/PKG-16711)
- [Upstream](https://github.com/wandb/wandb)
- Blocks: [PKG-14882 axolotl 0.17.0](https://anaconda.atlassian.net/browse/PKG-14882) — axolotl needs wandb on py3.14

### Explanation of changes:

- Enable py3.14 for wandb 0.27.2. Recipe-only change → build number 0 → 1 (all py3.10–3.14 variants rebuild).
- The only py3.14 blocker was `rdkit`, a **test-only** dependency with no py3.14 build on defaults. Runtime deps are all py3.14-ready.
  - `rdkit` gated to `# [py<314]` in `test.requires`.
  - `tests/unit_tests/test_media/test_media_logging.py` (module-level `from rdkit import Chem`) ignored on py3.14 via `# [py>313]`; the other rdkit test file was already ignored.
- Skip changed `[py<310 or py>313]` → `[py<310]`.


[PKG-16711]: https://anaconda.atlassian.net/browse/PKG-16711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ